### PR TITLE
Fix reloading error

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -3,7 +3,7 @@ require 'bundler'
 Bundler.require
 
 require 'rack/unreloader'
-Unreloader = Rack::Unreloader.new{AssetsTracker}
+Unreloader = Rack::Unreloader.new(:subclasses=>%w'Sinatra::Base'){AssetsTracker}
 Unreloader.require './app.rb'
 
 run Unreloader


### PR DESCRIPTION
After adding changes to the main app the reloader failed with a NameError. This had to do with unloading third party classes by the unreloader lib, fixed by unloading just subclases of the main app. 

More about this topic on the [rack-unreloader](https://github.com/jeremyevans/rack-unreloader#handling-subclasses) docs.